### PR TITLE
新增贊助商網站連結、允許 permalink 到個別贊助商

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -8,7 +8,7 @@ module.exports = {
   dev: {
 
     // Paths
-    assetsSubDirectory: 'static',
+    assetsSubDirectory: '2019/static',
     assetsPublicPath: '/',
     proxyTable: {},
 

--- a/src/assets/scss/_spotlight.scss
+++ b/src/assets/scss/_spotlight.scss
@@ -107,6 +107,12 @@
           height: 250px;
           width: auto;
         }
+
+        a {
+            width: 100%;
+            height: 100%;
+            color: transparent;
+        }
       }
 
       .content {

--- a/src/views/Sponsor.vue
+++ b/src/views/Sponsor.vue
@@ -15,8 +15,8 @@
             希望能藉由您的一份力量，來促成活動的舉行，讓更多學生能在舞台上展現自我成長。<br />
             歡迎您參與贊助，支持 SITCON、讓我們將每年的活動辦得盡善盡美！<br />
           </p>
-          <p><a href="https://sitcon.kktix.cc/events/sitcon2019-individual-sponsor" target="_blank" rel="noopener noreferrer">個人贊助辦法</a></p>
-          <p>企業贊助亦歡迎來信 <a href="mailto:contact@sitcon.org" target="_blank" rel="noopener noreferrer">contact@sitcon.org</a></p>
+          <p><a href="https://sitcon.kktix.cc/events/sitcon2019-individual-sponsor" target="_blank" rel="noopener">個人贊助辦法</a></p>
+          <p>企業贊助亦歡迎來信 <a href="mailto:contact@sitcon.org" target="_blank" rel="noopener">contact@sitcon.org</a></p>
         </div>
       </div>
       <div
@@ -24,11 +24,13 @@
         :key="index"
         class="spotlight card"
       >
-        <div class="card-container">
+        <div class="card-container" id="${sponsor.slug}">
           <div class="card-tag">
             <img :src="`/2019/static/img/${sponsor.level}.svg`" alt="">
           </div>
-          <div class="logo-image" :style="{ 'background-image': `url(/2019/static/img/sponsor/${sponsor.image})` }"></div>
+          <div class="logo-image" :style="{ 'background-image': `url(/2019/static/img/sponsor/${sponsor.image})` }">
+            <a href="${sponsor.url}" target="_blank" rel="external noopener nofollow"></a>
+          </div>
           <div class="content">
             <h1>{{ sponsor.name }}</h1>
             <p>{{ sponsor.description }}</p>

--- a/static/json/sponsor.json
+++ b/static/json/sponsor.json
@@ -30,13 +30,13 @@
   },
   {
     "name": "Skymizer",
-    "description": "Skymizer 是頂尖的編譯與虛擬化技術團隊，幫助深度學習與數位貨幣應用客戶建立各式虛擬機器與編譯器，縮短 time-to-market 時間。",
+    "description": "Skymizer 是頂尖的編譯與虛擬化技術團隊，幫助深度學習與區塊鏈應用客戶建立各式虛擬機器與編譯器，縮短 time-to-market 時間。",
     "level": "level-2",
     "image": "Skymizer.png"
   },
   {
     "name": "香港開放創意科技協會",
-    "description": "香港開放創意科技協會成立於2014年, 推廣開放標準, 自由及開放軟體, 開放硬體, 開放資料及共享創意。多年協辦香港開源年會，PyCon HK及支援SITCon x HK等。",
+    "description": "香港開放創意科技協會成立於2014年, 推廣開放標準, 自由及開放軟體, 開放硬體, 開放資料及共享創意。多年協辦香港開源年會，PyCon HK及支援SITCON x HK等。",
     "level": "level-2",
     "image": "HKCOTA.png"
   },

--- a/static/json/sponsor.json
+++ b/static/json/sponsor.json
@@ -1,24 +1,32 @@
 [
   {
     "name": "SITCON 學生計算機年會籌備團隊",
+    "slug": "sitcon",
+    "url": "https://hackfoldr.sitcon.org",
     "description": "SITCON 學生計算機年會 (Students’ Information Technology Conference) 是一個由各校同學於網路串聯發起，鼓勵自發學習、切磋成長的學生社群。\n因為熱愛資訊領域、知道尋找興趣相近夥伴的不容易，籌備團隊從 2013 年以來，便致力於連結對資訊科技相關領域有興趣的學生們，透過每年三月的研討會分享彼此所學，在每週的定期聚交流精進。發展至今，SITCON 除了是東亞最大的學生資訊社群與研討會，各地參與者也藉由夏令營、一小時學程式 (Hour of Code)、黑客松等不同的面向活動，推廣創新、實作、教學相長、以及開源貢獻的精神與理念；在台灣與海外各地，都有 SITCON 參與者的身影。",
     "level": "holder",
     "image": "sitcon.png"
   },
   {
     "name": "中央研究院資訊科學研究所",
+    "slug": "iis",
+    "url": "https://www.iis.sinica.edu.tw/",
     "description": "中央研究院資訊科學研究所於 1977 年開始設立籌備處，歷經五年籌備，於 1982 年 9 月正式成立研究所，是中央研究院數理組十一個單位之一。目前編制內有 39 位研究人員，另外有 29 位博士後研究學者，將近 300 位專任之資訊技術人員與非全時之研究助理，支援資訊領域之研究與系統之開發。「件件工作，反映自我，凡經我手，必為佳作」是全體同仁一致秉持的工作信念，重視工作之卓越品質，發揮最佳綜效之團隊精神。",
     "level": "co-holder",
     "image": "iis.png"
   },
   {
     "name": "財團法人開放文化基金會",
+    "slug": "ocf",
+    "url": "https://ocf.tw",
     "description": "開放文化基金會成立於 2014 年，由多個開源社群及活動組織共同發起，希望協助台灣蓬勃的開放社群，進一步促進開放源碼、開放資料、開放硬體等自由精神，能更廣泛的於各領域中應用，同時也協助政府、企業及非政府組織更能了解開源軟體的優勢、開放資料的重要，進而推廣開放協作的文化。 2015 年起我們除了支援本地社群主辦多場中大型活動，也和英國代表處、美國在台協會及世界銀行等單位共同舉辦各種主題講座，深耕台灣的開放文化並與國際交流。",
     "level": "co-holder",
     "image": "ocf.png"
   },
   {
     "name": "好苙整合設計",
+    "slug": "holistic",
+    "url": "",
     "description": "",
     "level": "level-1",
     "image": ""
@@ -30,24 +38,32 @@
   },
   {
     "name": "Skymizer",
+    "slug": "skymizer",
+    "url": "https://skymizer.com/",
     "description": "Skymizer 是頂尖的編譯與虛擬化技術團隊，幫助深度學習與區塊鏈應用客戶建立各式虛擬機器與編譯器，縮短 time-to-market 時間。",
     "level": "level-2",
     "image": "Skymizer.png"
   },
   {
     "name": "香港開放創意科技協會",
+    "slug": "hkcota",
+    "url": "https://cota.hk/",
     "description": "香港開放創意科技協會成立於2014年, 推廣開放標準, 自由及開放軟體, 開放硬體, 開放資料及共享創意。多年協辦香港開源年會，PyCon HK及支援SITCON x HK等。",
     "level": "level-2",
     "image": "HKCOTA.png"
   },
   {
     "name": "Tezos Southeast Asia",
+    "slug": "tezos",
+    "url": "https://tezos.com/",
     "description": "Tezos Southeast Asia 是一個致力於支持區塊鏈發展的非營利組織，藉由各項活動來促進商業研發和學術研究、推廣相關技術與科技之教育。",
     "level": "level-2",
     "image": ""
   },
   {
     "name": "HackMD",
+    "slug": "hackmd",
+    "url": "https://hackmd.io/",
     "description": "",
     "level": "thank",
     "image": "hackmd.png"


### PR DESCRIPTION
這個 PR 將會實作點一下 logo 就連結到贊助商的網站的功能；另外也允許使用 https://sitcon.org/2019/sponsor/#ocf 這種方式將頁面捲到特定的贊助商，方便聯繫贊助商 double-check。

還請白羊幫忙檢查一下會不會動了！